### PR TITLE
Modify let hoolock control simulcast enabled/disabled completelly

### DIFF
--- a/public/js/controllers.js
+++ b/public/js/controllers.js
@@ -25,7 +25,6 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
     },
     resolution: '1280x720',
     frameRate: 30,
-    _enableSimulcast: true
   },
     facePublisherPropsSD = {
       name: 'face',
@@ -46,7 +45,6 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
         },
         audio: true
       },
-      _enableSimulcast: true
     };
   $scope.facePublisherProps = facePublisherPropsHD;
 

--- a/tests/unit/controllersSpec.js
+++ b/tests/unit/controllersSpec.js
@@ -81,8 +81,7 @@ describe('OpenTok Meet controllers', function() {
           nameDisplayMode: 'off'
         },
         resolution: '1280x720',
-        frameRate: 30,
-        _enableSimulcast: true
+        frameRate: 30
       });
     });
 


### PR DESCRIPTION
Otherwise when hoolock doesn't set the simulcast property we were assuming it is set to false but in meet it is still true.