### PR TITLE
Subscriber preferred framerate

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -89,13 +89,16 @@ ot-layout button.resize-btn, ot-layout button.restrict-framerate-btn, ot-layout 
 }
 
 ot-layout button.resize-btn, ot-layout button.restrict-framerate-btn {
-    width: 25px;
     height: 25px;
     cursor: pointer;
     background-color: transparent;
     margin-top: 2px;
     right: 38px;
     border: none;
+}
+
+ot-layout button.resize-btn {
+    width: 25px;
 }
 
 ot-layout ot-subscriber button.restrict-framerate-btn {
@@ -110,7 +113,7 @@ ot-layout > .OT_big button.resize-btn:before {
     content: "\f267";
 }
 
-ot-layout button.restrict-framerate-btn.ion-ios7-speedometer-outline {
+ot-layout button.restrict-framerate-btn i.ion-ios7-speedometer-outline {
     -moz-transform: scaleX(-1);
     -webkit-transform: scaleX(-1);
     transform: scaleX(-1);
@@ -124,6 +127,15 @@ ot-layout > :hover button.resize-btn, ot-layout > :hover button.restrict-framera
     ot-layout button.OT_mode-on ~ button.restrict-framerate-btn {
     top: 0;
     opacity: 1;
+}
+
+ot-layout button.restrict-framerate-btn span.restrict-framerate-btn-text {
+    display: inline-block;
+    font-size: 16px;
+    text-align: right;
+    vertical-align: middle;
+    height: 100%;
+    margin-right: 5px;
 }
 
 ot-whiteboard:not(.ng-hide), ot-editor:not(.ng-hide) {

--- a/src/js/simulcast-service.js
+++ b/src/js/simulcast-service.js
@@ -16,11 +16,6 @@ angular.module('opentok-meet').factory('SimulcastService', ['debounce', '$rootSc
                 width: pixelWidth,
                 height: pixelHeight
               });
-              if (pixelWidth >= 320 && pixelHeight >= 240) {
-                subscriber.setPreferredFrameRate(null);
-              } else {
-                subscriber.setPreferredFrameRate(15);
-              }
             });
           });
         }, 1000));

--- a/src/js/subscriber-stats.js
+++ b/src/js/subscriber-stats.js
@@ -141,7 +141,8 @@ angular.module('opentok-meet').directive('subscriberStats', ['OTSession', 'Stats
         'Audio Bitrate: {{stats.audioBitrate}} kbps<br/>' +
         '</div><div ng-show="stats.video">' +
         'Video Packet Loss: {{stats.videoPacketLoss}}%<br/>' +
-        'Video Bitrate: {{stats.videoBitrate}} kbps' +
+        'Video Bitrate: {{stats.videoBitrate}} kbps<br/>' +
+        'Frame Rate: {{stats.video.frameRate || 0}} fps' +
         '</div><div ng-show="stats.info">' +
         'Origin server: {{stats.info.originServer}} <br/>' +
         'Edge server: {{stats.info.edgeServer}}' +

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -691,7 +691,8 @@ describe('OpenTok Meet App', function() {
                 'Audio Packet Loss: \\d\\d?\\.\\d\\d%<br>' +
                 'Audio Bitrate: \\d+ kbps<br>.*' +
                 'Video Packet Loss: \\d\\d?\\.\\d\\d%<br>' +
-                'Video Bitrate: \\d+ kbps.*' +
+                'Video Bitrate: \\d+ kbps<br>' +
+                'Frame Rate: \\d+(\\.\\d+)? fps.*' +
                 'Origin server:[\\w.-\\s]+<br>' +
                 'Edge server:[\\w.-\\s]+', 'gi');
               return statsRegexp.test(innerHTML);

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -663,17 +663,29 @@ describe('OpenTok Meet App', function() {
           expect(secondSubscriber.getAttribute('class')).not.toContain('OT_audio-only');
         });
 
-        it('restrictFramerate button toggles the icon and the title', function () {
+        it('restrictFramerate button toggles the icon and fps text', function () {
           var restrictFramerateBtn = secondSubscriber.element(by.css('.restrict-framerate-btn'));
-          expect(restrictFramerateBtn.getAttribute('class')).toContain('ion-ios7-speedometer');
-          expect(restrictFramerateBtn.getAttribute('title')).toBe('Restrict Framerate');
-          restrictFramerateBtn.click();
-          expect(restrictFramerateBtn.getAttribute('class')).toContain(
-            'ion-ios7-speedometer-outline');
-          expect(restrictFramerateBtn.getAttribute('title')).toBe('Unrestrict Framerate');
-          restrictFramerateBtn.click();
-          expect(restrictFramerateBtn.getAttribute('class')).toContain('ion-ios7-speedometer');
-          expect(restrictFramerateBtn.getAttribute('title')).toBe('Restrict Framerate');
+          var restrictFramerateIcon = restrictFramerateBtn.element(by.css('.restrict-framerate-btn-icon'));
+
+          function testRestrictFramerateBtn(options) {
+            if (!options.noClick) {
+              restrictFramerateBtn.click();
+            }
+            var restrictFramerateText = restrictFramerateBtn.element(by.css('.restrict-framerate-btn-text'));
+            expect(restrictFramerateText.isPresent()).toBe(options.text !== undefined);
+            if (options.text) {
+              expect(restrictFramerateText.getText()).toEqual(options.text);
+            }
+            expect(restrictFramerateIcon.getAttribute('class')).toContain(options.iconClass);
+          }
+
+          [
+            { text: undefined, iconClass: 'ion-ios7-speedometer', noClick: true},
+            { text: '15fps', iconClass: 'ion-ios7-speedometer-outline'},
+            { text: '7fps', iconClass: 'ion-ios7-speedometer-outline'},
+            { text: '1fps', iconClass: 'ion-ios7-speedometer-outline'},
+            { text: undefined, iconClass: 'ion-ios7-speedometer'}
+          ].forEach(testRestrictFramerateBtn);
         });
 
         it('stats button works', function() {

--- a/tests/protractor.conf.js
+++ b/tests/protractor.conf.js
@@ -1,3 +1,28 @@
+var path = require('path');
+var fs = require('fs');
+
+// Determine the protocol the app is running on
+var protocol = (function() {
+  var useSSL = fs.existsSync(path.join(__dirname, '..', 'server.key')) &&
+    fs.existsSync(path.join(__dirname, '..', 'server.crt'));
+  return process.env.HEROKU || !useSSL ? 'http' : 'https';
+})();
+
+// Determine the port the app is running on
+var port = (function() {
+  var appConfigFilePath = path.join(__dirname, '..', 'config.json');
+  var port = 5000;
+  if (process.env.HEROKU || process.env.TRAVIS) {
+    port = process.env.PORT;
+  } else if (fs.existsSync(appConfigFilePath)) {
+    port = require(appConfigFilePath).port;
+  }
+  return port;
+})();
+
+// Set the base URL based on the above protocol and port
+var baseUrl = protocol + '://localhost:' + port + '/';
+
 function getCapabilitiesFor(browserName, version) {
   var base = {
     'tunnel-identifier' : process.env.TRAVIS_JOB_NUMBER,
@@ -5,7 +30,7 @@ function getCapabilitiesFor(browserName, version) {
       process.env.TRAVIS_PULL_REQUEST,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'prerun': {
-      'executable': 'http://localhost:5000/SauceLabsInstaller.exe',
+      'executable': baseUrl + 'SauceLabsInstaller.exe',
       'background': false
     }
   };
@@ -30,7 +55,7 @@ switch(process.env.BROWSER) {
 
       capabilities: getCapabilitiesFor(process.env.BROWSER, process.env.BVER),
 
-      baseUrl: 'http://localhost:5000/',
+      baseUrl: baseUrl,
 
       framework: 'jasmine',
 
@@ -56,7 +81,7 @@ switch(process.env.BROWSER) {
 
       keepAlive: true,
 
-      baseUrl: 'http://localhost:5000/',
+      baseUrl: baseUrl,
 
       firefoxPath: process.env.BROWSERBIN,
 
@@ -93,7 +118,7 @@ switch(process.env.BROWSER) {
 
       directConnect: true,
 
-      baseUrl: 'http://localhost:5000/',
+      baseUrl: baseUrl,
 
       params: {
         testScreenSharing: false,

--- a/tests/unit/subscriberStatsSpec.js
+++ b/tests/unit/subscriberStatsSpec.js
@@ -84,7 +84,8 @@ describe('subscriber-stats', function() {
       'Audio Packet Loss: 20.00%<br>' +
       'Audio Bitrate: 0 kbps<br>.*' +
       'Video Packet Loss: 20.00%<br>' +
-      'Video Bitrate: 0 kbps', 'g')
+      'Video Bitrate: 0 kbps<br>' +
+      'Frame Rate: 0 fps', 'g')
     );
   });
 });
@@ -129,7 +130,8 @@ describe('StatsService', function () {
       video: {
         packetsLost: 200,
         packetsReceived: 1000,
-        bytesReceived: 1000
+        bytesReceived: 1000,
+        frameRate: 30
       },
       timestamp: 1000
     };
@@ -169,7 +171,8 @@ describe('StatsService', function () {
       video: {
         packetsLost: 300,
         packetsReceived: 1000,
-        bytesReceived: 2000
+        bytesReceived: 2000,
+        frameRate: 30
       },
       timestamp: 2000
     };
@@ -240,7 +243,8 @@ describe('StatsService', function () {
       video: {
         packetsLost: 300,
         packetsReceived: 1000,
-        bytesReceived: 2000
+        bytesReceived: 2000,
+        frameRate: 30
       },
       timestamp: 2000
     };
@@ -280,7 +284,8 @@ describe('StatsService', function () {
       video: {
         packetsLost: 300,
         packetsReceived: 1000,
-        bytesReceived: 2000
+        bytesReceived: 2000,
+        frameRate: 30
       },
       timestamp: 2000
     };


### PR DESCRIPTION
#### What is this PR doing?

1. Adds frame rate to subscriber stats via new `Subscriber.getStats()` property
2. Changes the behaviour of the Restrict Framerate button to toggle through multiple frame rates (15, 7, 1, unrestricted). It uses `Subscriber.setPreferredFrameRate()` for 15fps and 7fps, and `Subscriber.restrictFrameRate()` for 1fps.
3. Makes protractor config file determine the app port and protocol dynamically, rather than use hard coded value

#### How should this be manually tested?

*Subscriber Stats: Frame Rate*
1. Run meet app with it pointing to a version of `opentok.js` that has `video.frameRate` implemented in `Subscriber.getStats()`
2. Open the same room in two browser windows
3. Click stats button in top left
4. Confirm it contains something similar to `Frame Rate: 30 fps`

*Restrict Frame Rate Button*
1. Run meet app
2. Open the same room in two browser windows
3. In one of the windows, open the log console
4. Click the restrict framerate button
5. Observe it changes to an outline icon and has the text `15fps` beside it
6. Observe an update Rumor message sent with content `{"preferredFrameRate":15}`
7. Click the restrict framerate button
8. Observe it now has the text `7fps` beside it
9. Observe an update Rumor message sent with content `{"preferredFrameRate":7}`
10. Click the restrict framerate button
11. Observe it now has the text `1fps` beside it
12. Observe an update Rumor message sent with content `{"restrictFrameRate":true}`
13. Click the restrict framerate button
14. Observe it has reverted to the full icon with no text beside it
15. Observe 2 update Rumor messages sent with contents `{"preferredFrameRate":0}` and `{"restrictFrameRate":false}`

*Protractor Config*
1. Run meet app using arbitrary port set in `config.json`
2. Run `npm run integration`
3. Confirm tests run correctly
4. Run meet app with and without SSL (add/remove `server.key` and `server.crt`)
5. Run `npm run integration`
6. Confirm tests run correctly

#### What are the relevant tickets?

[OPENTOK-30134](https://tokbox.atlassian.net/browse/OPENTOK-30134)