### PR TITLE
Removing the audio-acquisition-problem alert

### DIFF
--- a/src/js/audio-acquisition-problem.js
+++ b/src/js/audio-acquisition-problem.js
@@ -17,8 +17,6 @@ angular.module('opentok-meet').directive('audioAcquisitionProblem',
             publisher.on('audioAcquisitionProblem', function() {
               scope.showAlert = true;
               scope.$apply();
-              $window.alert('Warning: audio acquisition problem you may need to quit and restart ' +
-              'your browser. If you are seeing this message please contact broken@tokbox.com.');
             });
             OTSession.off('otPublisherAdded', listenForIssue);
           } else {

--- a/tests/e2e/roomScenarios.js
+++ b/tests/e2e/roomScenarios.js
@@ -109,11 +109,6 @@ describe('Room', function() {
       expect(audioAcquisitionProblem.isDisplayed()).toBe(false);
       browser.driver.executeScript('OT.publishers.find().trigger(\'audioAcquisitionProblem\');')
       .then(function () {
-        var alertDialog = browser.switchTo().alert();
-        expect(alertDialog.getText()).toEqual('Warning: audio acquisition problem you may need ' +
-          'to quit and restart your browser. If you are seeing this message please contact ' +
-          'broken@tokbox.com.');
-        alertDialog.accept();
         expect(audioAcquisitionProblem.isDisplayed()).toBe(true);
       });
     });

--- a/tests/unit/audioAcquisitionProblemSpec.js
+++ b/tests/unit/audioAcquisitionProblemSpec.js
@@ -33,18 +33,4 @@ describe('audioAcquisitionProblem', function () {
       });
     }
   );
-
-  it('only triggers an alert once even if you have multiple publishers', function(done) {
-    OTSession.addPublisher(mockPublisher);
-    OTSession.addPublisher(OT.$.eventing({}));
-    OTSession.addPublisher(OT.$.eventing({}));
-    setTimeout(function() {
-      mockPublisher.trigger('audioAcquisitionProblem');
-      setTimeout(function() {
-        expect($window.alert.calls.count()).toBe(1);
-        done();
-      });
-    });
-
-  });
 });

--- a/tests/unit/audioAcquisitionProblemSpec.js
+++ b/tests/unit/audioAcquisitionProblemSpec.js
@@ -23,13 +23,11 @@ describe('audioAcquisitionProblem', function () {
   it('shows the warning icon and and alert when the publisher triggers audioAcquisitionProblem',
     function (done) {
       expect(scope.showAlert).toBe(false);
-      expect($window.alert).not.toHaveBeenCalled();
       OTSession.addPublisher(mockPublisher);
       setTimeout(function() {
         mockPublisher.trigger('audioAcquisitionProblem');
         setTimeout(function() {
           expect(scope.showAlert).toBe(true);
-          expect($window.alert).toHaveBeenCalled();
           done();
         });
       });


### PR DESCRIPTION
Now that we are displaying publish errors and the audio acquisition problem is just a publish error