### PR TITLE
Enable experimental error reporting

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -17,6 +17,8 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
   $scope.editorUnread = false;
   $scope.leaving = false;
 
+  OT._.enableExperimentalErrorReporting();
+
   var facePublisherPropsHD = {
     name: 'face',
     width: '100%',

--- a/tests/unit/controllersSpec.js
+++ b/tests/unit/controllersSpec.js
@@ -25,6 +25,7 @@ describe('OpenTok Meet controllers', function() {
         // Override checkSystemRequirements so that IE works without a plugin
         return true;
       };
+      spyOn(OT._, 'enableExperimentalErrorReporting');
       scope.session = jasmine.createSpyObj('Session', ['disconnect', 'on', 'trigger']);
       scope.session.connection = {
         connectionId: 'mockConnectionId'
@@ -70,6 +71,10 @@ describe('OpenTok Meet controllers', function() {
 
     it('should define connections', function () {
       expect(scope.connections).toBe(MockOTSession.connections);
+    });
+
+    it('should enable OpenTok.js error reporting', function () {
+      expect(OT._.enableExperimentalErrorReporting).toHaveBeenCalled();
     });
 
     it('should define facePublisherProps', function() {


### PR DESCRIPTION
Use the undocumented `OT._.enableExperimentalErrorReporting` API to enable error reporting on meet.tokbox.com.

Integration tests won't pass until this new API has been deployed.