### PR TITLE
Add crossorigin="anonymous"

### DIFF
--- a/views/room.ejs
+++ b/views/room.ejs
@@ -12,7 +12,7 @@
         <title>OpenTok Meet : <%=room%></title>
         <link href='//fonts.googleapis.com/css?family=Ropa+Sans' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="/css/main.css" media="screen" title="no title" charset="utf-8">
-        <script src="https://tbdev.tokbox.com/v2/js/opentok.js"></script>
+        <script src="https://tbdev.tokbox.com/v2/js/opentok.js" crossorigin="anonymous"></script>
         <script src="https://d3brof7fu9hlhe.cloudfront.net/static/rtcstats.min.js" type="text/javascript" charset="utf-8"></script>
 
         <link rel="stylesheet" href="//code.ionicframework.com/ionicons/1.4.1/css/ionicons.min.css" type="text/css" media="screen" title="no title" charset="utf-8">

--- a/views/screen.ejs
+++ b/views/screen.ejs
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="//code.ionicframework.com/ionicons/1.4.1/css/ionicons.min.css" type="text/css" media="screen" title="no title" charset="utf-8">
         <link rel="stylesheet" href="/css/main.css" media="screen" title="no title" charset="utf-8">
         <link rel="stylesheet" href="/css/screen.css" media="screen" title="no title" charset="utf-8">
-        <script src="//tbdev.tokbox.com/webrtc/v2/js/opentok.js" type="text/javascript" charset="utf-8"></script>
+        <script src="//tbdev.tokbox.com/webrtc/v2/js/opentok.js" crossorigin="anonymous" type="text/javascript" charset="utf-8"></script>
         <script src="/js/commons.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/screen.bundle.min.js" type="text/javascript" charset="utf-8"></script>
         <script type="text/javascript">

--- a/views/whiteboard.ejs
+++ b/views/whiteboard.ejs
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <title><%=room%>: Whiteboard</title>
-        <script src="//tbdev.tokbox.com/webrtc/v2/js/opentok.js" type="text/javascript" charset="utf-8"></script>
+        <script src="//tbdev.tokbox.com/webrtc/v2/js/opentok.js" crossorigin="anonymous" type="text/javascript" charset="utf-8"></script>
         <script src="/js/commons.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/whiteboard.bundle.min.js" type="text/javascript" charset="utf-8"></script>
         <script type="text/javascript">


### PR DESCRIPTION
The OpenTok JS SDK has experimental error reporting. For this to work well
across domains, we need to do the following:

* Ensure the OpenTok JS SDK is served with `Access-Control-Allow-Origin: *`
* Ensure the script is loaded with the attribute `crossorigin="anonymous"`