### PR TITLE
OPENTOK-31614 - Enable error reporting using OTProperties instead of private method

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -17,10 +17,6 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
   $scope.editorUnread = false;
   $scope.leaving = false;
 
-  if (OT._ && OT._.enableExperimentalErrorReporting) {
-    OT._.enableExperimentalErrorReporting();
-  }
-
   var facePublisherPropsHD = {
     name: 'face',
     width: '100%',

--- a/tests/unit/controllersSpec.js
+++ b/tests/unit/controllersSpec.js
@@ -25,7 +25,6 @@ describe('OpenTok Meet controllers', function() {
         // Override checkSystemRequirements so that IE works without a plugin
         return true;
       };
-      spyOn(OT._, 'enableExperimentalErrorReporting');
       scope.session = jasmine.createSpyObj('Session', ['disconnect', 'on', 'trigger']);
       scope.session.connection = {
         connectionId: 'mockConnectionId'
@@ -71,10 +70,6 @@ describe('OpenTok Meet controllers', function() {
 
     it('should define connections', function () {
       expect(scope.connections).toBe(MockOTSession.connections);
-    });
-
-    it('should enable OpenTok.js error reporting', function () {
-      expect(OT._.enableExperimentalErrorReporting).toHaveBeenCalled();
     });
 
     it('should define facePublisherProps', function() {

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -12,6 +12,9 @@
         <title>OpenTok Meet : <%=room%></title>
         <link href='//fonts.googleapis.com/css?family=Ropa+Sans' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="/css/main.css" media="screen" title="no title" charset="utf-8">
+        <script type="text/javascript">
+          window.OTProperties = { enableErrorReporting: true };
+        </script>
         <script src="https://tbdev.tokbox.com/v2/js/opentok.js"></script>
         <script src="https://d3brof7fu9hlhe.cloudfront.net/static/rtcstats.min.js" type="text/javascript" charset="utf-8"></script>
 

--- a/views/screen.ejs
+++ b/views/screen.ejs
@@ -7,6 +7,9 @@
         <link rel="stylesheet" href="//code.ionicframework.com/ionicons/1.4.1/css/ionicons.min.css" type="text/css" media="screen" title="no title" charset="utf-8">
         <link rel="stylesheet" href="/css/main.css" media="screen" title="no title" charset="utf-8">
         <link rel="stylesheet" href="/css/screen.css" media="screen" title="no title" charset="utf-8">
+        <script type="text/javascript">
+          window.OTProperties = { enableErrorReporting: true };
+        </script>
         <script src="//tbdev.tokbox.com/webrtc/v2/js/opentok.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/commons.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/screen.bundle.min.js" type="text/javascript" charset="utf-8"></script>

--- a/views/whiteboard.ejs
+++ b/views/whiteboard.ejs
@@ -5,6 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <title><%=room%>: Whiteboard</title>
+        <script type="text/javascript">
+          window.OTProperties = { enableErrorReporting: true };
+        </script>
         <script src="//tbdev.tokbox.com/webrtc/v2/js/opentok.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/commons.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/whiteboard.bundle.min.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
Replace call to `OT._.enableExperimentalErrorReporting` with `OTProperties.enableErrorReporting` setting.