### PR TITLE
Remove electron meet protocol redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,27 @@ Opentok app with screen sharing using the WebRTC screen sharing and Archiving fe
 ## Deploying to meet.tokbox.com
 
 If you push to the master branch of this repo [Travis](https://travis-ci.org/opentok/opentok-meet) and [BrowserStack](https://browserstack.com/automate) tests will run and when they pass meet.tokbox.com will be updated.
+
+## Electron
+
+Electron is an optional dependency because it requires Cairo on your system and isn't necessary for theest of opentok-meet. If you run into problems below, try this:
+
+```sh
+brew update
+brew install cairo
+npm install
+```
+
+During development the electron version can be quickly started by running
+
+```sh
+npm run electron
+```
+
+And a dmg for installation can be created with
+
+```sh
+npm run electron-build
+```
+
+To create a signed build (so the user is not warned when starting the app), you will need an appropriate certificate available on your machine (getting one is beyond the scope of this guide). If the certificate is available, it can be used by adding `-- --osx-sign` to the command above.

--- a/electron/app/main.js
+++ b/electron/app/main.js
@@ -4,41 +4,25 @@ const {
   app,
   BrowserWindow,
   globalShortcut,
-  protocol,
+  // protocol,
 // eslint-disable-next-line import/no-extraneous-dependencies
 } = require('electron');
 
-const clone = require('lodash/clone');
+// const clone = require('lodash/clone');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 const windows = new Set();
 
-protocol.registerStandardSchemes(['meet'], { secure: true });
-
-function registerProtocol() {
-  protocol.registerHttpProtocol('meet', (req, callback) => {
-    const redirectReq = clone(req);
-
-    if (redirectReq.url.indexOf('meet://home') === 0) {
-      redirectReq.url = redirectReq.url.replace('meet://home', 'https://meet.tokbox.com');
-    } else {
-      redirectReq.url = redirectReq.url.replace('meet://', 'https://');
-    }
-
-    callback(redirectReq);
-  });
-}
-
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', registerProtocol);
+// app.on('ready', registerProtocol);
 const readyPromise = new Promise(resolve => app.on('ready', resolve));
 
 let createWindowCalled = false;
 
-function createWindow(url = 'meet://home') {
+function createWindow(url = 'https://meet.tokbox.com/') {
   createWindowCalled = true;
 
   readyPromise.then(() => {
@@ -76,7 +60,15 @@ readyPromise.then(() => {
   }
 });
 
-app.on('open-url', (ev, url) => {
+app.on('open-url', (ev, urlParam) => {
+  let url = urlParam;
+
+  if (url.indexOf('meet://home') === 0) {
+    url = url.replace('meet://home', 'https://meet.tokbox.com');
+  } else {
+    url = url.replace('meet://', 'https://');
+  }
+
   createWindow(url);
 });
 

--- a/electron/app/main.js
+++ b/electron/app/main.js
@@ -4,11 +4,8 @@ const {
   app,
   BrowserWindow,
   globalShortcut,
-  // protocol,
 // eslint-disable-next-line import/no-extraneous-dependencies
 } = require('electron');
-
-// const clone = require('lodash/clone');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -17,7 +14,6 @@ const windows = new Set();
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-// app.on('ready', registerProtocol);
 const readyPromise = new Promise(resolve => app.on('ready', resolve));
 
 let createWindowCalled = false;


### PR DESCRIPTION
#### What is this PR doing?
Fixes the issue @donaltoomey found where rooms failed to load by removing electron's proxy/redirect of meet:// urls and just uses https://. (meet:// urls in safari still work.)

#### How should this be manually tested?
Build the app and check rooms load and meet://home/roomy-mcroomface in safari opens the app.

(Here's the one I built: https://files.slack.com/files-pri/T029F8997-F4MQ2V67L/download/meet-electron.dmg)

#### What are the relevant tickets?
N/A
