### PR TITLE
Fix h264 in Chrome 56

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "start": "node app.js",
     "unit": "karma start tests/karma.conf.js --single-run",
     "preintegration": "npm run update-webdriver",
-    "integration": "protractor-flake -- tests/protractor.conf.js --max-attempts=5",
+    "integration": "protractor-flake --max-attempts=5 -- tests/protractor.conf.js",
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
     "protractor": "node_modules/.bin/protractor tests/protractor-chrome.conf.js",

--- a/src/js/h264/modify-sdp.js
+++ b/src/js/h264/modify-sdp.js
@@ -22,7 +22,8 @@ module.exports = function(h264, dtx) {
           if (h264) {
             var oldSDP = sdp.sdp;
             sdp.sdp = sdp.sdp.replace('120 121 126 97', '126 97 120 121'); // FF
-            sdp.sdp = sdp.sdp.replace('100 101 107', '107 100 101'); // Chrome 56
+            sdp.sdp = sdp.sdp.replace(/(.*?m=video )(.*?) 100 101 (.*?)107(.*?)/gi,
+              '$1$2 107 100 101 $3$4'); // Chrome 56
             sdp.sdp = sdp.sdp.replace(/(.*?m=video )(.*?) 96 98 (.*?)100(.*?)/gi,
               '$1$2 100 96 98 $3$4'); // Chrome Canary
             if (oldSDP === sdp.sdp) {


### PR DESCRIPTION
#### What is this PR doing?

We made a change in opentok.js that deprioritised H.264 for Edge. This broke our brittle sdp replacement function. I'm now using a slightly more resilient RegExp.

#### How should this be manually tested?

Make sure that H.264 works for Chrome 56.
