### PR TITLE
Don't redirect to electron if RTCPeerConn present

### DIFF
--- a/src/js/safari-electron-redirect.js
+++ b/src/js/safari-electron-redirect.js
@@ -1,6 +1,7 @@
 'use strict';
 
 if (
+  !window.RTCPeerConnection &&
   navigator.userAgent.indexOf('Safari') !== -1 &&
   navigator.userAgent.indexOf('Chrome') === -1
 ) {


### PR DESCRIPTION
#### What is this PR doing?
Prevents redirection to `/electron/download` if `RTCPeerConnection` is defined.

#### What are the relevant tickets?
[OPENTOK-33313](https://tokbox.atlassian.net/browse/OPENTOK-33313)
