### PR TITLE
Use p2p session for the H.264 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 env:
   matrix:
     - BROWSER=chrome  BVER=stable
-    - BROWSER=firefox BVER=46.0.1
+    - BROWSER=firefox BVER=45.0.2
     - BROWSER=ie BVER=11  SAUCELABS=true
     - BROWSER=ie BVER=10  SAUCELABS=true
     - BROWSER=firefox BVER=stable

--- a/tests/e2e/h264Scenarios.js
+++ b/tests/e2e/h264Scenarios.js
@@ -53,7 +53,7 @@ describe('H264', function() {
   describe('with 2 participants', function() {
     var secondBrowser;
     beforeEach(function() {
-      browser.get('/' + roomName + '?h264=true');
+      browser.get('/' + roomName + 'p2p?h264=true');
       secondBrowser = browser.forkNewDriverInstance(true);
       secondBrowser.browserName = browser.browserName;
     });


### PR DESCRIPTION
Right now Rumor is stripping out H.264 for Mantis sessions so we need to use P2P.