### PR TITLE
Change sdp to *only* have h264 when h264 flag is on

### DIFF
--- a/src/js/h264/modify-sdp.js
+++ b/src/js/h264/modify-sdp.js
@@ -1,3 +1,5 @@
+var useH264Only = require('./useH264Only.js');
+
 module.exports = function(h264, dtx) {
   console.log('Intercept settings', dtx, h264);
 
@@ -21,11 +23,7 @@ module.exports = function(h264, dtx) {
           console.log('Intercept setLocalDescription');
           if (h264) {
             var oldSDP = sdp.sdp;
-            sdp.sdp = sdp.sdp.replace('120 121 126 97', '126 97 120 121'); // FF
-            sdp.sdp = sdp.sdp.replace(/(.*?m=video )(.*?) 100 101 (.*?)107(.*?)/gi,
-              '$1$2 107 100 101 $3$4'); // Chrome 56
-            sdp.sdp = sdp.sdp.replace(/(.*?m=video )(.*?) 96 98 (.*?)100(.*?)/gi,
-              '$1$2 100 96 98 $3$4'); // Chrome Canary
+            sdp.sdp = useH264Only(sdp.sdp);
             if (oldSDP === sdp.sdp) {
               console.warn('Could not modify SDP to turn on H.264', oldSDP);
             }

--- a/src/js/h264/useH264Only.js
+++ b/src/js/h264/useH264Only.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = function useH264Only(sdp) {
+  var lines = sdp.split('\r\n');
+
+  var mLineIndex = lines.findIndex(function(line) {
+    return line.indexOf('m=video') === 0;
+  });
+
+  var mLine = lines[mLineIndex];
+
+  var payloadTypes = function () {
+    var match = mLine.match(/[0-9][0-9 ]*$/);
+
+    if (!match) {
+      return [];
+    }
+
+    return match[0].split(' ');
+  }();
+
+  var h264Lines = lines.filter(function(line) {
+    return /^a=rtpmap.* H264/.test(line);
+  });
+
+  if (h264Lines.length === 0) {
+    console.warn('No H264 found. Returning original SDP.');
+    return sdp;
+  }
+
+  var h264TypeCodes = null;
+
+  try {
+    h264TypeCodes = h264Lines.map(function(line) {
+      return line.split(':')[1].split(' ')[0];
+    });
+  } catch (error) {
+    console.error('Something went wrong getting the h264 type code:', {
+      line: h264Lines[0],
+      error: error
+    });
+
+    return sdp;
+  }
+
+  var newPayloadTypes = h264TypeCodes;
+  var oldPayloadTypes = payloadTypes.filter(function(type) {
+    return h264TypeCodes.indexOf(type) === -1;
+  });
+
+  var newMLine = lines[mLineIndex].replace(payloadTypes.join(' '), newPayloadTypes.join(' '));
+  lines[mLineIndex] = newMLine;
+
+  return lines.filter(function(line) {
+    return !new RegExp('^a=[a-z-]*:(' + oldPayloadTypes.join('|') + ') ').test(line);
+  }).join('\r\n');
+};


### PR DESCRIPTION
#### What is this PR doing?
Locates H264 in sdp and updates it to only include that, rather than just reordering the m line numbers to change priority.

#### How should this be manually tested?
Search 'sdpTransforms' in the console when publishing and check that only H264 is present in the modified local offer.

#### What are the relevant tickets?
[OPENTOK-33695](https://tokbox.atlassian.net/browse/OPENTOK-33695) (this PR helps but does NOT resolve the ticket)
