### PR TITLE
Fix H.264

### DIFF
--- a/src/js/h264/modify-sdp.js
+++ b/src/js/h264/modify-sdp.js
@@ -32,12 +32,12 @@ module.exports = function(h264, dtx) {
         };
         return pc;
     };
+    newPeerConnection.prototype = OrigPeerConnection.prototype;
 
     ['RTCPeerConnection', 'webkitRTCPeerConnection', 'mozRTCPeerConnection'].forEach(function(obj) {
         // Override objects if they exist in the window object
         if (window.hasOwnProperty(obj)) {
-            window[obj] = newPeerConnection;
-            window[obj].prototype =  newPeerConnection.prototype;
+          window[obj] = newPeerConnection;
         }
     });
   }


### PR DESCRIPTION
#### What is this PR doing?

Set the prototype properly on the peerconnection function. Otherwise we were getting an error about missing `addEventListener` on the PeerConnection.

#### How should this be manually tested?

Add ?h264=true on the end of the room and make sure you can publish.