### PR TITLE
audioAcquisitionProblem event now has an event with a method property

### DIFF
--- a/tests/e2e/roomScenarios.js
+++ b/tests/e2e/roomScenarios.js
@@ -161,7 +161,7 @@ describe('Room', function() {
       }, 10000);
       var audioAcquisitionProblem = element(by.css('#facePublisher audio-acquisition-problem'));
       expect(audioAcquisitionProblem.isDisplayed()).toBe(false);
-      browser.driver.executeScript('OT.publishers.find().trigger(\'audioAcquisitionProblem\');')
+      browser.driver.executeScript('OT.publishers.find().trigger(\'audioAcquisitionProblem\', { method: \'mock\' });')
       .then(function () {
         expect(audioAcquisitionProblem.isDisplayed()).toBe(true);
       });

--- a/tests/unit/audioAcquisitionProblemSpec.js
+++ b/tests/unit/audioAcquisitionProblemSpec.js
@@ -25,7 +25,7 @@ describe('audioAcquisitionProblem', function () {
       expect(scope.showAlert).toBe(false);
       OTSession.addPublisher(mockPublisher);
       setTimeout(function() {
-        mockPublisher.trigger('audioAcquisitionProblem');
+        mockPublisher.trigger('audioAcquisitionProblem', { method: 'mock' });
         setTimeout(function() {
           expect(scope.showAlert).toBe(true);
           done();


### PR DESCRIPTION
#### What is this PR doing?

audioAcquisitionProblem event now has an event with a method property so passing the method in our tests too. These tests were causing exceptions to be logged in Sentry.

#### How should this be manually tested?

Just make sure the tests pass and that there aren't new errors being logged in Sentry.

