### PR TITLE
Don't forward people to the iOS app anymore

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -67,18 +67,6 @@ module.exports = function (app, config, redis, ot, redirectSSL) {
         RoomStore.getRoom(room, apiKey, secret, goToRoom);
       },
       html: function() {
-        var ua = req.headers['user-agent'];
-        // If we're on iOS forward them to the iOS App
-        if (/like Mac OS X/.test(ua)) {
-          var iOSRegex = /CPU( iPhone)? OS ([0-9\._]+) like Mac OS X/.exec(ua),
-            iOS = iOSRegex && iOSRegex.length > 2 && iOSRegex[2].replace(/_/g, '.');
-          if (iOS) {
-            res.render('roomiOS', {
-              room: room
-            });
-            return;
-          }
-        }
         res.render('room', {
           opentokJs: config.opentokJs,
           room: room,

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -6,6 +6,7 @@
         <meta content="utf-8" http-equiv="encoding">
         <meta http-equiv="X-UA-Compatible" content="chrome=1">
         <meta name="mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1">
         <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/<%=chromeExtensionId%>">
         <link rel="icon" sizes="128x128" href="icon.png">


### PR DESCRIPTION
#### What is this PR doing?

meet.tokbox.com works with iOS11 so let's not forward users to install the iOS app anymore.

#### How should this be manually tested?

Join a room on iOS 11 and make sure it works.
