### PR TITLE
 Fix wonky expand bug

### DIFF
--- a/src/js/directives.js
+++ b/src/js/directives.js
@@ -232,8 +232,11 @@ angular.module('opentok-meet').directive('draggable', ['$document', '$window',
         }
         scope.toggleExpand = () => {
           scope.expanded = !scope.expanded;
-          $rootScope.$broadcast('otLayout');
-          scope.$emit('changeSize');
+          setTimeout(() => {
+            // Need to do this async so there's enough time for the view to update
+            $rootScope.$broadcast('otLayout');
+            scope.$emit('changeSize');
+          }, 10);
         };
         angular.element(element).parent().on('dblclick', scope.toggleExpand);
       },


### PR DESCRIPTION
#### What is this PR doing?

Dispatch otLayout asynchronously so there is enough time for the view to update. The issue was that we were updating the layout before the DOM had changed so you had to double click twice to get it to work and then if someone new joined or the DOM updated for any other reason then it would redraw and things would be out of sync.

#### How should this be manually tested?

Open 3 tabs so you're subscribing to 2 participants. Double click on one of the participants (or click the expand button) and make sure that the video expands as expected. 
