### PR TITLE
OPENTOK-37443 - Enable stereo for HD publishers

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -37,6 +37,7 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
       },
       usePreviousDeviceSelection: true,
       resolution: '1280x720',
+      enableStereo: true,
       frameRate: 30,
     };
     const facePublisherPropsSD = {


### PR DESCRIPTION
#### What is this PR doing?

Enable stereo for HD publishers. If you want to not use stereo then you can publish SD. But by default everyone publishes HD and with Stereo audio.

#### How should this be manually tested?

Make sure that enableStereo is being passed to initPublisher.

#### What are the relevant tickets?

OPENTOK-37443

