### PR TITLE
OPENTOK-37942 Fix meet not showing codec information

### DIFF
--- a/src/js/subscriber-stats.js
+++ b/src/js/subscriber-stats.js
@@ -75,10 +75,10 @@ angular.module('opentok-meet').factory('StatsService', ['$http', '$interval', 'b
           };
         }
 
-        if (subscriberStats.audioCodec && subscriberStats.videoCodec) {
-          currStats.videoCodec = subscriberStats.videoCodec;
-          currStats.audioCodec = subscriberStats.audioCodec;
-        }
+        ['audio', 'video'].forEach((type) => {
+          const key = `${type}Codec`;
+          if (subscriberStats[key]) { currStats[key] = subscriberStats[key]; }
+        });
 
         subscriberStats.onStats(currStats);
 


### PR DESCRIPTION
#### What is this PR doing?

Fix meet not showing codec information.

Meet was only showing codec information if both audio and video codecs
were present.

#### How should this be manually tested?

1. Have just a video track
2. See that video codec is displayed

#### What are the relevant tickets?

Resolves [OPENTOK-37942](https://tokbox.atlassian.net/browse/OPENTOK-37942)

