### PR TITLE
OPENTOK-38176: Use _allowSafariSimulcast flag

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -40,6 +40,7 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
       resolution: '1280x720',
       enableStereo: true,
       frameRate: 30,
+      _allowSafariSimulcast: true,
     };
     const facePublisherPropsSD = {
       name: 'face',
@@ -48,6 +49,7 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
       style: {
         nameDisplayMode: 'off',
       },
+      _allowSafariSimulcast: true,
     };
     $scope.facePublisherProps = facePublisherPropsHD;
 

--- a/tests/unit/controllersSpec.js
+++ b/tests/unit/controllersSpec.js
@@ -68,7 +68,7 @@ describe('OpenTok Meet controllers', () => {
     });
 
     it('should define facePublisherProps', () => {
-      expect(scope.facePublisherProps).toEqual({
+      expect(scope.facePublisherProps).toEqual(jasmine.objectContaining({
         name: 'face',
         width: '100%',
         height: '100%',
@@ -79,7 +79,7 @@ describe('OpenTok Meet controllers', () => {
         resolution: '1280x720',
         enableStereo: true,
         frameRate: 30,
-      });
+      }));
     });
 
     it('should have a notMine method that works', () => {


### PR DESCRIPTION
#### What is this PR doing?
Adds `_allowSafariSimulcast` flag to the publisher props so that, when implemented in opentok.js, safari will be added to the whitelist

webrtc-js PR: https://github.com/opentok/webrtc-js/pull/2858

#### How should this be manually tested?
Set a breakpoint at the start of initPublisher and check that the `options` variable contains `{ _allowSafariSimulcast: true }`.

#### What are the relevant tickets?
[OPENTOK-38176](https://tokbox.atlassian.net/browse/OPENTOK-38176)