### PR TITLE
fix aec removing stereo [OPENTOK-38959]

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -38,7 +38,6 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
       },
       usePreviousDeviceSelection: true,
       resolution: '1280x720',
-      enableStereo: true,
       frameRate: 30,
       _allowSafariSimulcast: true,
     };

--- a/tests/unit/controllersSpec.js
+++ b/tests/unit/controllersSpec.js
@@ -77,7 +77,6 @@ describe('OpenTok Meet controllers', () => {
         },
         usePreviousDeviceSelection: true,
         resolution: '1280x720',
-        enableStereo: true,
         frameRate: 30,
       }));
     });


### PR DESCRIPTION
#### What is this PR doing?
disabling stereo as aec is not supported for it by Chrome

#### How should this be manually tested?
use meet and see there is no echo

#### What are the relevant tickets?
https://tokbox.atlassian.net/browse/OPENTOK-38959

