### PR TITLE
Add streamId to widget stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 services:
 - redis-server
 sudo: required
-dist: trusty
+dist: xenial
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_install:
 # Work around for chrome installation in trusty
 - if [[ "$BROWSER" = "chrome" ]]; then
-    sudo apt-get update && sudo apt-get upgrade;
+    sudo apt-get update && sudo apt-get install dpkg;
   fi
 - export DISPLAY=:99.0
 - if [ -f /etc/init.d/xvfb ];then sh -e /etc/init.d/xvfb start; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
 - '8'
 before_install:
+# Work around for chrome installation in trusty
+- if [[ "$BROWSER" = "chrome" ]]; then
+    sudo apt-get update && sudo apt-get upgrade;
+  fi
 - export DISPLAY=:99.0
 - if [ -f /etc/init.d/xvfb ];then sh -e /etc/init.d/xvfb start; fi
 - npm i -g npm@6
@@ -15,7 +19,7 @@ addons:
 services:
 - redis-server
 sudo: required
-dist: xenial
+dist: trusty
 matrix:
   fast_finish: true
 

--- a/src/js/publisher-stats.js
+++ b/src/js/publisher-stats.js
@@ -75,6 +75,7 @@ function PublisherStatsDirective(OTSession, $interval) {
         const generalStats = {
           width: currentPublisher.videoWidth(),
           height: currentPublisher.videoHeight(),
+          streamId: currentPublisher.streamId,
           stats: mappedStats,
         };
 

--- a/src/js/subscriber-stats.js
+++ b/src/js/subscriber-stats.js
@@ -72,6 +72,7 @@ angular.module('opentok-meet').factory('StatsService', ['$http', '$interval', 'b
           subscriberStats.lastStats.info = {
             originServer: info.originServer,
             edgeServer: info.edgeServer,
+            streamId: subscriber.streamId
           };
         }
 

--- a/src/js/subscriber-stats.js
+++ b/src/js/subscriber-stats.js
@@ -72,7 +72,7 @@ angular.module('opentok-meet').factory('StatsService', ['$http', '$interval', 'b
           subscriberStats.lastStats.info = {
             originServer: info.originServer,
             edgeServer: info.edgeServer,
-            streamId: subscriber.streamId
+            streamId: subscriber.streamId,
           };
         }
 

--- a/src/templates/publisher-stats.html
+++ b/src/templates/publisher-stats.html
@@ -24,4 +24,6 @@
       </div>
     </div>
   </div>
+
+  <label>StreamId</label><span data-for="streamId" class="mono">{{generalStats.streamId}}</span><br />
 </div>

--- a/src/templates/subscriber-stats.html
+++ b/src/templates/subscriber-stats.html
@@ -23,6 +23,7 @@
     </div>
   </div>
   <div ng-show="stats.info">
+    <label>StreamId</label><span data-for="streamId" class="mono">{{stats.info.streamId}}</span><br />
     <label>Origin server</label> <span data-for="originServer" class="mono">{{stats.info.originServer}}</span><br />
     <label>Edge server</label> <span data-for="edgeServer" class="mono">{{stats.info.edgeServer}}</span><br />
   </div>


### PR DESCRIPTION
#### What is this PR doing?
Add streamId to widget stats

#### How should this be manually tested?
When publishing, StreamId field should be present on the bottom of the publisher stats widget.
When subscribing, StreamId field should be present above the origin server field in the subscriber stats widget

#### What are the relevant tickets?
n/a
