### PR TITLE
Removing the native apps link

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -51,11 +51,6 @@
                 </div>
                 <input type="submit" name="joinRoom" value="Join" id="joinRoomBtn">
             </form>
-            <div id="nativeLink">
-              <a href="https://mobile-meet.tokbox.com" target="_blank">
-                <img src="/images/white-phone.png"><br>
-                Get the mobile or desktop app for iOS, Android or Mac OS</a>
-            </div>
         </div>
         <script src="/js/commons.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/login.bundle.min.js" type="text/javascript" charset="utf-8"></script>

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -97,12 +97,6 @@
             <strong>Disclaimer</strong>: This application is running on an unstable version of the OpenTok infrastructure.
             Use <a href="https://opentok-meet.herokuapp.com/<%=room%>">opentok-meet.herokuapp.com</a> for the production version.
             </p>
-            <div id="nativeLink">
-            <a href="https://mobile-meet.tokbox.com" target="_blank">
-                <img src="/images/white-phone.png">
-                Remember to try the mobile app for iOS or Android or Desktop app for Mac OS!
-            </a>
-            </div>
         </div>
         <reconnecting-overlay id="reconnectingOverlay"
             ng-if="reconnecting"


### PR DESCRIPTION
#### What is this PR doing?
Removing the native apps link since this is not longer available.

#### How should this be manually tested?
Go to https://meet.tokbox.com/:
- Check _Get the mobile or desktop app for iOS, Android or Mac OS_ div is present.
Also go to https://meet.tokbox.com/anyrandomroom/:
- Check _Get the mobile or desktop app for iOS, Android or Mac OS_ div is present.

Now run this PR in your local and check both cases. The _div_ should not be present.

#### What are the relevant tickets?
N/A

