### PR TITLE
Add local setup instructions for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,48 @@
 [![Code Climate](https://codeclimate.com/github/opentok/opentok-meet/badges/gpa.svg)](https://codeclimate.com/github/opentok/opentok-meet)
 [![Test Coverage](https://codeclimate.com/github/opentok/opentok-meet/badges/coverage.svg)](https://codeclimate.com/github/opentok/opentok-meet/coverage)
 
-opentok-meet
-===============
+# opentok-meet
 
 Opentok app with screen sharing using the WebRTC screen sharing and Archiving features. You can check it out running at [meet.tokbox.com](https://meet.tokbox.com).
 
 ## Disclaimer
 
+> This is a fork of the [opentok-meet](https://github.com/aullman/opentok-meet) project that deploys to [meet.tokbox.com](https://meet.tokbox.com). It is pointing to the OpenTok nightly environment which is experimental and likely to break. It also includes experimental features.
 
->This is a fork of the [opentok-meet](https://github.com/aullman/opentok-meet) project that deploys to [meet.tokbox.com](https://meet.tokbox.com). It is pointing to the OpenTok nightly environment which is experimental and likely to break. It also includes experimental features.
-
->If you wish to fork this project, please fork the [parent project](https://github.com/aullman/opentok-meet).
+> If you wish to fork this project, please fork the [parent project](https://github.com/aullman/opentok-meet).
 
 ## Deploying to meet.tokbox.com
 
 If you push to the master branch of this repo [Travis](https://travis-ci.org/opentok/opentok-meet) and [BrowserStack](https://browserstack.com/automate) tests will run and when they pass meet.tokbox.com will be updated.
 
+## Requirements
+
+- [node.js](https://nodejs.org/en/download/releases/) (version 8)
+- [redis](https://redis.io/) (Recommended to install via homebrew on mac: [see instructions](https://medium.com/@petehouston/install-and-config-redis-on-mac-os-x-via-homebrew-eb8df9a4f298))
+
+## Running meet locally
+
+- Copy the contents of `config.json.sample` into `config.json` and add your credentials.
+
+- Ensure redis is running (e.g. `redis-server` on mac)
+
+- Install npm dependencies
+
+```
+npm i
+```
+
+- Run the server:
+
+```
+npm start
+```
+
+You should now see the app running at http://localhost:3000/
+
 ## Electron
 
-Electron is an optional dependency because it requires Cairo on your system and isn't necessary for theest of opentok-meet. If you run into problems below, try this:
+Electron is an optional dependency because it requires Cairo on your system and isn't necessary for the rest of opentok-meet. If you run into problems below, try this:
 
 ```sh
 brew update

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Opentok app with screen sharing using the WebRTC screen sharing and Archiving fe
 
 ## Disclaimer
 
-> This is a fork of the [opentok-meet](https://github.com/aullman/opentok-meet) project that deploys to [meet.tokbox.com](https://meet.tokbox.com). It is pointing to the OpenTok nightly environment which is experimental and likely to break. It also includes experimental features.
-
-> If you wish to fork this project, please fork the [parent project](https://github.com/aullman/opentok-meet).
+> This project deploys to [meet.tokbox.com](https://meet.tokbox.com). It is pointing to the OpenTok nightly environment which is experimental and likely to break. It also includes experimental features.
+> This was originally a fork of [aullman/opentok-meet](https://github.com/aullman/opentok-meet) but is now diverged and is not updated with changes made there.
 
 ## Deploying to meet.tokbox.com
 
@@ -24,6 +23,7 @@ If you push to the master branch of this repo [Travis](https://travis-ci.org/ope
 ## Running meet locally
 
 - Copy the contents of `config.json.sample` into `config.json` and add your credentials.
+  :warning: Note: the default config points to tbdev. If you intend to use a production api key you must change `apiUrl` and `opentokJs` to point to production endpoints.
 
 - Ensure redis is running (e.g. `redis-server` on mac)
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ If you push to the master branch of this repo [Travis](https://travis-ci.org/ope
 
 - Ensure redis is running (e.g. `redis-server` on mac)
 
-- Install npm dependencies
+- Install npm dependencies and build the web project
 
 ```
 npm i
+npm run build
 ```
 
 - Run the server:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm": "6.x"
   },
   "scripts": {
-    "postinstall": "webpack",
+    "postinstall": "npm run build",
     "build": "webpack",
     "test": "./node_modules/.bin/run-tests",
     "tdd": "node node_modules/karma/bin/karma start tests/karma-debug.conf.js",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "scripts": {
     "postinstall": "webpack",
+    "build": "webpack",
     "test": "./node_modules/.bin/run-tests",
     "tdd": "node node_modules/karma/bin/karma start tests/karma-debug.conf.js",
     "start": "node app.js",


### PR DESCRIPTION
#### What is this PR doing?
Adding local setup instructions to readme for running the app locally.

#### How should this be manually tested?
Formatted readme can be viewed on the branch: https://github.com/maikthomas/opentok-meet/tree/readme-local-setup
You could follow the steps I added to the readme and try to run to the app.

#### What are the relevant tickets?
There is no ticket for this.
