### PR TITLE
Add grid centering to custom layout. [OPENTOK-43671]

### DIFF
--- a/plugins/archiving/stylesheet.js
+++ b/plugins/archiving/stylesheet.js
@@ -1,4 +1,5 @@
 module.exports = () => `/* use-typed-stream-elements */
+/* grid-do-center */
 
 videostream, screenstream {
  float: left;


### PR DESCRIPTION
#### What is this PR doing?
This PR adds grid centering to the custom layout used by meet for archiving

#### How should this be manually tested?
Do an archive with at least 3 cameras (or 3 screens) and validate that the third stream is centred horizontally in the bottom row

#### What are the relevant tickets?
https://jira.vonage.com/browse/OPENTOK-43671
