### PR TITLE
OPENTOK-43815: Check for invalid token role

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -65,7 +65,7 @@ module.exports = (app, config, redis, ot, redirectSSL) => {
               apiKey: (pApiKey && pSecret) ? pApiKey : config.apiKey,
               p2p: RoomStore.isP2P(room),
               token: otSDK.generateToken(sessionId, {
-                role: tokenRole,
+                role: tokenRole || 'moderator',
               }),
             });
           }

--- a/server/routes.js
+++ b/server/routes.js
@@ -38,7 +38,13 @@ module.exports = (app, config, redis, ot, redirectSSL) => {
     const room = req.param('room');
     const apiKey = req.param('apiKey');
     const secret = req.param('secret');
-    const tokenRole = req.query.tokenRole;
+    let { tokenRole } = req.query;
+
+    const isValidTokenRole = role =>
+      /^(?:moderator|publisher|subscriber)$/.test(role);
+
+    tokenRole = isValidTokenRole(tokenRole) ? tokenRole : 'publisher';
+
     res.format({
       json() {
         const goToRoom = (err, sessionId, pApiKey, pSecret) => {
@@ -61,7 +67,7 @@ module.exports = (app, config, redis, ot, redirectSSL) => {
               apiKey: (pApiKey && pSecret) ? pApiKey : config.apiKey,
               p2p: RoomStore.isP2P(room),
               token: otSDK.generateToken(sessionId, {
-                role: tokenRole || 'publisher',
+                role: tokenRole,
               }),
             });
           }

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,5 +1,6 @@
 const OpenTok = require('opentok');
 const roomstore = require('./roomstore.js');
+const isValidTokenRole = require('../src/js/isValidTokenRole');
 
 module.exports = (app, config, redis, ot, redirectSSL) => {
   const RoomStore = roomstore(redis, ot);
@@ -39,9 +40,6 @@ module.exports = (app, config, redis, ot, redirectSSL) => {
     const apiKey = req.param('apiKey');
     const secret = req.param('secret');
     let { tokenRole } = req.query;
-
-    const isValidTokenRole = role =>
-      /^(?:moderator|publisher|subscriber)$/.test(role);
 
     tokenRole = isValidTokenRole(tokenRole) ? tokenRole : 'publisher';
 

--- a/src/js/isValidTokenRole.js
+++ b/src/js/isValidTokenRole.js
@@ -1,0 +1,3 @@
+module.exports = function isValidTokenRole(tokenRole) {
+  return /^(?:moderator|publisher|subscriber)$/.test(tokenRole);
+};

--- a/src/js/login/controller.js
+++ b/src/js/login/controller.js
@@ -1,3 +1,4 @@
+const isValidTokenRole = require('../isValidTokenRole');
 const isp2p = room => room && room.toLowerCase().indexOf('p2p') > -1;
 
 angular.module('opentok-meet-login', [])
@@ -9,16 +10,24 @@ angular.module('opentok-meet-login', [])
     $scope.dtx = false;
     $scope.joinRoom = () => {
       let url = $window.location.href + encodeURIComponent($scope.room);
+
       if ($scope.roomType !== 'normal') {
         url += `/${$scope.roomType}`;
       }
+
+      if (!isValidTokenRole($scope.tokenRole)) {
+        $scope.tokenRole = 'moderator';
+      }
+
       if ($scope.tokenRole) {
         url += `?tokenRole=${$scope.tokenRole}`;
       }
+
       if ($scope.dtx) {
         const precursor = $scope.tokenRole ? '&' : '?';
         url += `${precursor}dtx=true`;
       }
+
       $window.location.href = url;
     };
     $scope.p2p = false;

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -10,3 +10,4 @@ require('./notificationsSpec.js');
 require('./otErrorsSpec.js');
 require('./subscriberReportSpec.js');
 require('./microphonePickerSpec.js');
+require('./isValidTokenRoleSpec.js');

--- a/tests/unit/isValidTokenRoleSpec.js
+++ b/tests/unit/isValidTokenRoleSpec.js
@@ -1,0 +1,17 @@
+const isValidTokenRole = require('../../src/js/isValidTokenRole');
+
+describe('isValidTokenRole', () => {
+  const tokenRoles = ['moderator', 'publisher', 'subscriber'];
+
+  tokenRoles.forEach((tokenRole) => {
+    it(`should return true since token role ${tokenRole} is valid`, () => {
+      expect(isValidTokenRole('moderator')).toBe(true);
+    });
+
+    const invalidTokenRole = `${tokenRole}s`;
+
+    it(`should return false since token role ${invalidTokenRole} is valid`, () => {
+      expect(isValidTokenRole(invalidTokenRole)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/isValidTokenRoleSpec.js
+++ b/tests/unit/isValidTokenRoleSpec.js
@@ -10,7 +10,7 @@ describe('isValidTokenRole', () => {
 
     const invalidTokenRole = `${tokenRole}s`;
 
-    it(`should return false since token role ${invalidTokenRole} is valid`, () => {
+    it(`should return false since token role ${invalidTokenRole} is invalid`, () => {
       expect(isValidTokenRole(invalidTokenRole)).toBe(false);
     });
   });

--- a/tests/unit/login/controllerSpec.js
+++ b/tests/unit/login/controllerSpec.js
@@ -84,6 +84,13 @@ describe('OpenTok Login Page', () => {
         scope.joinRoom();
         expect(windowMock.location.href).toEqual('mockURL/foo/screen?tokenRole=subscriber');
       });
+
+      it('defaults the url to moderator for screen roomType, when the tokenRole is invalid', () => {
+        scope.roomType = 'screen';
+        scope.tokenRole = 'boo';
+        scope.joinRoom();
+        expect(windowMock.location.href).toEqual('mockURL/foo/screen?tokenRole=moderator');
+      });
     });
 
     it('watches the room and updates p2p', () => {


### PR DESCRIPTION
#### What is this PR doing?
Checks for invalid token role.  If valid, a default is assumed.

#### How should this be manually tested?
Confirm that invalid token roles can cause meet to crash
* Checkout `master` branch
* Build and run meet
* Open http://localhost:3000/testing-if-meet-crashes?tokenRole=moderators
* Notice that meet crashes

Confirm that invalid token role no longer causes meet to crash
* Checkout this branch
* Build and run meet
* Open http://localhost:3000/testing-if-meet-crashes?tokenRole=moderators
* Notice that meet doesn't crash

#### What are the relevant tickets?
https://jira.vonage.com/browse/OPENTOK-43815
