### PR TITLE
[OPENTOK-43733] Log when RTT is really high

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3596,9 +3596,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -7253,9 +7253,9 @@
       "integrity": "sha1-sa5Cg8xcJVwp346zfe+i+4l+H00="
     },
     "opentok-solutions-logging": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/opentok-solutions-logging/-/opentok-solutions-logging-1.1.1.tgz",
-      "integrity": "sha512-XRpusv4xQpczkp4ZzXBC9Il4jVV+DsK7/DLNvTVjbNAy/iv0SUmmHSWTRcKHE+TSiRs8d0MfsrbRtOYkugV39w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/opentok-solutions-logging/-/opentok-solutions-logging-1.1.3.tgz",
+      "integrity": "sha512-PV5wrtrWax/MuHpnTVw2AXPOwpQxLWOhkP+Dc9+RkZ38xLraWtHNVxnyWqmnCFX9x4xzdh/61cvBR2uNAZgfsw==",
       "requires": {
         "axios": "^0.21.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -3586,6 +3594,11 @@
       "requires": {
         "imul": "^1.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -7239,6 +7252,14 @@
       "resolved": "https://registry.npmjs.org/opentok-layout-js/-/opentok-layout-js-1.1.0.tgz",
       "integrity": "sha1-sa5Cg8xcJVwp346zfe+i+4l+H00="
     },
+    "opentok-solutions-logging": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/opentok-solutions-logging/-/opentok-solutions-logging-1.1.1.tgz",
+      "integrity": "sha512-XRpusv4xQpczkp4ZzXBC9Il4jVV+DsK7/DLNvTVjbNAy/iv0SUmmHSWTRcKHE+TSiRs8d0MfsrbRtOYkugV39w==",
+      "requires": {
+        "axios": "^0.21.1"
+      }
+    },
     "opentok-test-scripts": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/opentok-test-scripts/-/opentok-test-scripts-3.6.1.tgz",
@@ -7379,7 +7400,7 @@
     },
     "paper": {
       "version": "0.9.25",
-      "resolved": "https://registry.npmjs.org/paper/-/paper-0.9.25.tgz",
+      "resolved": "http://registry.npmjs.org/paper/-/paper-0.9.25.tgz",
       "integrity": "sha1-6t3OfcchS2wgv9dfWv8AlbyCTFA=",
       "requires": {
         "canvas": ">=1.2.9",
@@ -7412,7 +7433,7 @@
         },
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "boom": {
@@ -7438,7 +7459,7 @@
         },
         "form-data": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "requires": {
             "async": "^2.0.1",
@@ -7495,7 +7516,7 @@
         },
         "request": {
           "version": "2.61.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.61.0.tgz",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.61.0.tgz",
           "integrity": "sha1-aXPLKslIhfAmk/VU7sZEgdYBP58=",
           "requires": {
             "aws-sign2": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "opentok-angular": "https://github.com/albertoacn/opentok-angular.git#OPENTOK-43696",
     "opentok-camera-filters": "^2.0.1",
     "opentok-editor": "^0.3.3",
+    "opentok-solutions-logging": "^1.1.1",
     "opentok-textchat": "^1.2.3",
     "opentok-whiteboard": "^1.2.1",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "opentok-angular": "https://github.com/albertoacn/opentok-angular.git#OPENTOK-43696",
     "opentok-camera-filters": "^2.0.1",
     "opentok-editor": "^0.3.3",
-    "opentok-solutions-logging": "^1.1.1",
+    "opentok-solutions-logging": "^1.1.3",
     "opentok-textchat": "^1.2.3",
     "opentok-whiteboard": "^1.2.1",
     "path": "^0.12.7",

--- a/src/js/helpers/analytics.js
+++ b/src/js/helpers/analytics.js
@@ -12,7 +12,7 @@ const init = (session, action) => {
     userAgent: navigator.userAgent,
   };
 
-  otkAnalytics = new OTKAnalytics(otkanalyticsData);
+  otkAnalytics = new OTKAnalytics(otkanalyticsData, { loggingUrl: 'hlg.dev.tokbox.com/qa/logging/ClientEvent' });
 
   const sessionInfo = {
     sessionId: session.sessionId,

--- a/src/js/helpers/analytics.js
+++ b/src/js/helpers/analytics.js
@@ -1,0 +1,41 @@
+const OTKAnalytics = require('opentok-solutions-logging');
+
+let otkAnalytics;
+
+const init = (session, action) => {
+  const otkanalyticsData = {
+    clientVersion: OT.version,
+    source: window.location.href,
+    action,
+    name: 'meet.tokbox.com',
+    componentId: 'meet.tokbox.com',
+    userAgent: navigator.userAgent,
+  };
+
+  otkAnalytics = new OTKAnalytics(otkanalyticsData);
+
+  const sessionInfo = {
+    sessionId: session.sessionId,
+    connectionId: session.connection.connectionId,
+    partnerId: session.apiKey,
+  };
+
+  otkAnalytics.addSessionInfo(sessionInfo);
+};
+
+const log = (data) => {
+  otkAnalytics.logEvent(data);
+};
+
+const isInitiated = () => otkAnalytics;
+
+const destroy = () => {
+  otkAnalytics = null;
+};
+
+module.exports = {
+  init,
+  log,
+  isInitiated,
+  destroy,
+};

--- a/src/js/helpers/publisher-rtt-watcher.js
+++ b/src/js/helpers/publisher-rtt-watcher.js
@@ -1,0 +1,50 @@
+const analytics = require('./analytics');
+
+const RTT_THRESHOLD = 10000;
+const INTERVAL_DELAY = 30 * 1000;
+
+let interval;
+let previousRttValues = {};
+
+const stop = () => {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+    analytics.destroy();
+    previousRttValues = {};
+  }
+};
+
+const start = (publisher, session) => {
+  stop();
+
+  interval = setInterval(() => {
+    // init analytics
+    if (session.connection.connectionId && !analytics.isInitiated()) {
+      analytics.init(session);
+    }
+
+    publisher.getRtcStatsReport().then((stats) => {
+      const reports = stats[0].rtcStatsReport;
+      reports.forEach((report) => {
+        if (report.type === 'remote-inbound-rtp') {
+          const { roundTripTime, kind } = report;
+          if (roundTripTime >= RTT_THRESHOLD) {
+            const data = { rtt: roundTripTime, kind };
+            if (kind.toString() in previousRttValues) {
+              data.previousRtt = previousRttValues[kind];
+            }
+            analytics.log(data);
+          } else {
+            previousRttValues[kind] = report.roundTripTime;
+          }
+        }
+      });
+    });
+  }, INTERVAL_DELAY);
+};
+
+module.exports = {
+  start,
+  stop,
+};

--- a/src/js/publisher-stats.js
+++ b/src/js/publisher-stats.js
@@ -1,5 +1,6 @@
 const publisherStatsHTML = require('../templates/publisher-stats.html');
 require('../css/publisher-stats.css');
+const publisherRttWatcher = require('./helpers/publisher-rtt-watcher');
 
 function PublisherStatsDirective(OTSession, $interval) {
   function link(scope) {
@@ -99,8 +100,11 @@ function PublisherStatsDirective(OTSession, $interval) {
       if (newValue === undefined) {
         return;
       }
-
       currentPublisher = newValue;
+      publisherRttWatcher.start(currentPublisher, OTSession.session);
+      currentPublisher.on('streamDestroyed', () => {
+        publisherRttWatcher.stop();
+      });
     });
   }
 

--- a/src/js/webview-controller.js
+++ b/src/js/webview-controller.js
@@ -23,7 +23,7 @@ angular.module('opentok-meet').controller('WebViewComposerAppCtrl', ['$scope', '
       stream.connection.connectionId !== $scope.session.connection.connectionId;
 
     $scope.getPublisher = id => OTSession.publishers.filter(x => x.id === id)[0];
-    
+
     // Fetch the room info
     RoomService.getRoom().then((roomData) => {
       if ($scope.session) {


### PR DESCRIPTION
#### What is this PR doing?
This PR adds a watcher to the publisher so that we can detect when we have really high values of rtt (=> 10000) either for video or audio.

#### How should this be manually tested?
Will be hard to test since we can't reproduce the scenario. But, we can make a change to see how it will log:

- Change the line 32 in the file `publisher-rtt-watcher.js` to this:
```
if (roundTripTime <= RTT_THRESHOLD) {
```
- npm run build
- npm start
- Open localhost:3000 and join a room
- go to network tab and check that every 30s you should see a new ClientEvent log with a data similar to this:

```
clientSystemTime: 1629925770740
clientVersion: "v2.20.3"
componentId: "meet.tokbox.com"
connectionId: "90c76575-2007-4d5b-b4b7-b6cd533747c1"
guid: "2c8e322b-0feb-4b6d-859d-2bed9ea98dbb"
kind: "video"
logVersion: "2"
name: "meet.tokbox.com"
partnerId: "100"
rtt: 0.218
sessionId: "1_MX4xMDB-fjE2Mjk5MjU1OTA5MzF-YUJpN1JHTTVnUC95TjRTMWtvRHZnVDlDfn4"
source: "http://localhost:3000/dfdsffds?tokenRole=moderator"
userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
```

Because of this change to test it, you will see two logs, one for audio and one for video. In real like, it will only log the video kind that has the high value. In case both have high values, it will log both (audio and video).

#### What are the relevant tickets?
OPENTOK-43733
