### PR TITLE
OPENTOK-44945: Meet should use DTX as a default

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -33,7 +33,10 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
     $scope.startingWebviewComposing = false;
 
     const url = new URL($window.location.href);
-    const enableDtx = url.searchParams.get('dtx') === 'true';
+    let enableDtx = true;
+    if (url.searchParams.get('dtx') === 'false') {
+      enableDtx = false;
+    }
 
     const facePublisherPropsHD = {
       name: 'face',

--- a/src/js/login/controller.js
+++ b/src/js/login/controller.js
@@ -9,7 +9,7 @@ angular.module('opentok-meet-login', [])
     $scope.roomType = 'normal';
     $scope.tokenRole = 'moderator';
     $scope.advanced = false;
-    $scope.dtx = false;
+    $scope.dtx = true;
     $scope.joinRoom = () => {
       const location = new URL($window.location.href);
       let url = `${location.origin}/${encodeURIComponent($scope.room)}`;
@@ -26,9 +26,9 @@ angular.module('opentok-meet-login', [])
         url += `?tokenRole=${$scope.tokenRole}`;
       }
 
-      if ($scope.dtx) {
+      if (!$scope.dtx) {
         const precursor = $scope.tokenRole ? '&' : '?';
-        url += `${precursor}dtx=true`;
+        url += `${precursor}dtx=false`;
       }
 
       $window.location.href = url;

--- a/tests/e2e/dtxScenarios.js
+++ b/tests/e2e/dtxScenarios.js
@@ -30,7 +30,13 @@ xdescribe('dtx', () => {
       roomField.sendKeys(roomName);
       dtx.click();
       submit.click();
-      expect(browser.getCurrentUrl()).toBe(`${browser.baseUrl + roomName}?dtx=true`);
+      expect(browser.getCurrentUrl()).toBe(`${browser.baseUrl + roomName}?dtx=false`);
+    });
+
+    it('should not add the dtx parameter on the end of the url by default', () => {
+      roomField.sendKeys(roomName);
+      submit.click();
+      expect(browser.getCurrentUrl()).toBe(`${browser.baseUrl + roomName}`);
     });
   });
 });


### PR DESCRIPTION
#### What is this PR doing?

JS SDK recently added support for Opus DTX.  This PR updates meet so that is uses DTX by default.

A meet session can be created via url or via login page. For both cases DTX should be enabled by default. 
e2e tests for dtxScenarios has been updated as well.

#### How should this be manually tested?

_**Creating a session via login page**_ 

1. Run the app and make sure you're on the login page. Click on _advanced_ and view that the DTX checkbox is checked by default. 

2. Enter a room name and enter the session. Check to make sure DTX is enabled by opening the console and under _All levels_, select _Verbose_. Search for **_'usedtx'_** and see that it appears in the console. 

_**Creating a session via url**_ 

3. Create a session via url without specifying DTX configuration. For example: _http://localhost:3000/testing_

4. DTX should be enabled even though we did not specifically specify so. Confirm this by repeating step 2.

#### What are the relevant tickets?

Resolves [OPENTOK-44945](https://jira.vonage.com/browse/OPENTOK-44945)

