### PR TITLE
OPENTOK-44484: Make force mute buttons in meet so that it can enable and disable

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -86,6 +86,23 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
       });
     };
 
+    $scope.muteOnEntry = () => {
+      const myStream = OT.publishers.find().stream;
+      $scope.session.forceMuteAll([myStream]).then(() => {
+        console.log('Enable MuteOnEntry complete');
+      }).catch((error) => {
+        console.error('Enable MuteOnEntry failed', error);
+      });
+    };
+
+    $scope.disableMuteOnEntry = () => {
+      $scope.session.disableForceMute().then(() => {
+        console.log('Disable MuteOnEntry complete');
+      }).catch((error) => {
+        console.error('Disable MuteOnEntry failed', error);
+      });
+    };
+
     $scope.forceMuteAllExcludingPublisherStream = () => {
       const streamId = (OT.publishers.find() || {}).streamId;
       const streams = (OT.sessions.find() || {}).streams;

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -143,6 +143,10 @@
 
             <button type="button" name="muteAllExcludingPublishingStream" id="muteAllExcludingPublishingStream" ng-click="forceMuteAllExcludingPublisherStream()" class="icon-left ion gray" ng-if="isModerator">Mute All Excluding Publishing Stream</button>
 
+            <button type="button" name="enableMuteOnEntry" id="enableMuteOnEntry" ng-click="muteOnEntry()" class="icon-left ion gray" ng-if="isModerator">Enable Mute On Entry</button>
+
+            <button type="button" name="disableMuteOnEntry" id="disableMuteOnEntry" ng-click="disableMuteOnEntry()" class="icon-left ion gray" ng-if="isModerator">Disable Mute On Entry</button>
+
             <span id="publishUI">
                 <button name="publish" id="publishBtn" ng-click="togglePublish(true)" ng-class="{green: !publishing, red: publishing}" class="publish-btn icon-left ion ion-ios7-videocam" title="WebCam">{{ publishing ? 'Unpublish' : 'Publish HD'}}</button>
                 <button name="publishSD" id="publishSDBtn" ng-if="!publishing" ng-click="togglePublish(false)" class="publish-btn green icon-left ion ion-ios7-videocam" title="WebCam">Publish SD</button>


### PR DESCRIPTION
#### What is this PR doing?

This PR is adding **enableMuteOnEntry** and **disableMuteOnEntry** buttons in meet.

#### How should this be manually tested?

**Testing with 3 users** 

1. On the login page, create a room and make sure you are a moderator 
2. In the room, select the **Enable Mute On Entry** button and make sure you (moderator) are not muted
3. Join the room as another user as any other role, and make sure you are muted. 
4. Go back to the original moderator tab and select the  **Disable Mute On Entry** button
5. Go back to the tab of the other user and make sure you are still muted (Disable Mute On Entry will not unmute users that are currently muted)
6. Join the room as another user as any other role, and make sure you are not muted

Note: the Mic button on the bottom row of buttons does get updated with 'Enable Mute On Entry'. To check to see if you are muted/unmuted, hover over your camera preview on the top right corner and look to see that the microphone icon does/does not have a line through it. 

#### What are the relevant tickets?
https://jira.vonage.com/browse/OPENTOK-44484
