### PR TITLE
OPENTOK-47128 Fix npm build by removing git:// dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "codemirror": {
-      "version": "5.62.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.2.tgz",
-      "integrity": "sha512-tVFMUa4J3Q8JUd1KL9yQzQB0/BJt7ZYZujZmTPgo/54Lpuq3ez4C8x/ATUY/wv7b7X3AUq8o3Xd+2C5ZrCGWHw=="
+      "version": "5.65.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.2.tgz",
+      "integrity": "sha512-SZM4Zq7XEC8Fhroqe3LxbEEX1zUPWH1wMr5zxiBuiUF64iYOUH/JI88v4tBag8MiBS8B8gRv8O1pPXGYXQ4ErA=="
     },
     "coffee-script": {
       "version": "1.8.0",
@@ -7289,13 +7289,12 @@
       }
     },
     "opentok-editor": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/opentok-editor/-/opentok-editor-0.3.3.tgz",
-      "integrity": "sha1-BxSqy1msnkgVEOzUa5eMAZyDD98=",
+      "version": "git+https://github.com/maikthomas/opentok-editor.git#e572ab56c5353378bb14ef90f08b6a3d8958b3be",
+      "from": "git+https://github.com/maikthomas/opentok-editor.git#master",
       "requires": {
         "angular": "^1.5.5",
         "codemirror": "^5.14.2",
-        "ot": "git://github.com/aullman/ot.js.git#master"
+        "ot": "git+https://github.com/aullman/ot.js.git#master"
       }
     },
     "opentok-layout-js": {
@@ -7420,8 +7419,8 @@
       }
     },
     "ot": {
-      "version": "git://github.com/aullman/ot.js.git#1c7e0a97a168d1df535826e7203bd3ede5f092fe",
-      "from": "git://github.com/aullman/ot.js.git#master"
+      "version": "git+https://github.com/aullman/ot.js.git#1c7e0a97a168d1df535826e7203bd3ede5f092fe",
+      "from": "git+https://github.com/aullman/ot.js.git#master"
     },
     "p-limit": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "opentok": "^2.6.2",
     "opentok-angular": "https://github.com/albertoacn/opentok-angular.git#master-screen-canvas",
     "opentok-camera-filters": "^2.0.1",
-    "opentok-editor": "^0.3.3",
+    "opentok-editor": "https://github.com/maikthomas/opentok-editor.git#master",
     "opentok-solutions-logging": "^1.1.3",
     "opentok-textchat": "^1.2.3",
     "opentok-whiteboard": "^1.2.1",


### PR DESCRIPTION
#### What is this PR doing?
npm install was broken by git:// protocol used in dependency. 
I changed it to https:// in this repo
https://github.com/maikthomas/opentok-editor/commit/e572ab56c5353378bb14ef90f08b6a3d8958b3be
and then used that commit for our opentok-editor dependency in meet.

#### How should this be manually tested?
- Checkout locally and run `npm install`
- ensure it works

#### What are the relevant tickets?
OPENTOK-47128
